### PR TITLE
Updating the SketchUp Discourse plugin to use the new login service. …

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -1,0 +1,6 @@
+
+en:
+  site_settings:
+    sketchup_authorize_url: 'Authorize URL for SketchUp Login Service (including the callback destination)'
+    sketchup_sso_cookie_name: 'Name of the cookie needed for the userinfo URL'
+    sketchup_userinfo_url: 'Userinfo URL for SketchUp Login Service'

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,0 +1,5 @@
+login:
+
+  sketchup_authorize_url: 'https://login.sketchup.com/login/trimbleid?destination=http://forums.sketchup.com/auth/sketchup/callback'
+  sketchup_sso_cookie_name: 'SID'
+  sketchup_userinfo_url: 'https://login.sketchup.com/api/v1.0/users/'


### PR DESCRIPTION
… A custom OmniAuth strategy was necessary too since the new login service does not implement OpenID.

Discussed previously in a thread on Discourse Meta.